### PR TITLE
Add support for the NN_IPV4ONLY option

### DIFF
--- a/c_src/enm.h
+++ b/c_src/enm.h
@@ -68,6 +68,7 @@
 #define ENM_SNDBUF      18
 #define ENM_RCVBUF      19
 #define ENM_NODELAY     20
+#define ENM_IPV4ONLY    21
 
 #define IDXSHFT(P,I,SH) ((int)(((unsigned char)((P)[I]))<<(SH)))
 #define GETINT16(P) (IDXSHFT(P,0,8) | IDXSHFT(P,1,0))

--- a/c_src/enm_drv.c
+++ b/c_src/enm_drv.c
@@ -361,6 +361,7 @@ enm_create_socket(EnmData* d, EnmArgs* args)
         case ENM_SNDBUF:
         case ENM_RCVBUF:
         case ENM_NODELAY:
+        case ENM_IPV4ONLY:
             if ((res = enm_setopts_priv(d, opt, args)) != 0)
                 return res;
             break;

--- a/src/enm.erl
+++ b/src/enm.erl
@@ -80,6 +80,7 @@
 -define(ENM_SNDBUF, 18).
 -define(ENM_RCVBUF, 19).
 -define(ENM_NODELAY, 20).
+-define(ENM_IPV4ONLY, 21).
 
 -type nnstate() :: #state{}.
 -type nnsocket() :: port().
@@ -105,13 +106,15 @@
 -type nnsndbufopt() :: {sndbuf, pos_integer()}.
 -type nnrcvbufopt() :: {rcvbuf, pos_integer()}.
 -type nnnodelayopt() :: {nodelay, boolean()}.
+-type nnipv4only() :: {ipv4only, boolean()}.
 -type nngetopt() :: nntypeopt() | nnactiveopt() | nnmodeopt() |
                     nndeadlineopt() | nnresendivlopt() |
                     nnsndbufopt() | nnrcvbufopt() | nnnodelayopt().
 -type nngetopts() :: [nngetopt()].
 -type nnsetopt() :: nnactiveopt() | nnmodeopt() |
                     nndeadlineopt() | nnsubscribeopt() | nnunsubscribeopt() |
-                    nnresendivlopt() | nnsndbufopt() | nnrcvbufopt() | nnnodelayopt().
+                    nnresendivlopt() | nnsndbufopt() | nnrcvbufopt() |
+                    nnnodelayopt() | nnipv4only().
 -type nnsetopts() :: [nnsetopt()].
 -type nnopenopt() :: nnbindopt() | nnconnectopt() | nnrawopt() |
                      nnactiveopt() | nnmodeopt() |
@@ -512,6 +515,8 @@ validate_opt_names([rcvbuf|Opts], Bin) ->
     validate_opt_names(Opts, <<Bin/binary, ?ENM_RCVBUF>>);
 validate_opt_names([nodelay|Opts], Bin) ->
     validate_opt_names(Opts, <<Bin/binary, ?ENM_NODELAY>>);
+validate_opt_names([ipv4only|Opts], Bin) ->
+    validate_opt_names(Opts, <<Bin/binary, ?ENM_IPV4ONLY>>);
 validate_opt_names([Opt|_], _) ->
     error(badarg, [Opt]).
 
@@ -570,6 +575,12 @@ validate_opts([{nodelay,NoDelay}|Opts], Type, Bin) when is_boolean(NoDelay) ->
                false -> ?ENM_FALSE
            end,
     validate_opts(Opts, Type, <<Bin/binary, ?ENM_NODELAY, Bool:8>>);
+validate_opts([{ipv4only, IPv4Only}|Opts], Type, Bin) when is_boolean(IPv4Only) ->
+    Bool = case IPv4Only of
+               true -> ?ENM_TRUE;
+               false -> ?ENM_FALSE
+           end,
+    validate_opts(Opts, Type, <<Bin/binary, ?ENM_IPV4ONLY, Bool:8>>);
 validate_opts(Opts, Type, Bin) ->
     error(badarg, [Opts, Type, Bin]).
 

--- a/test/enm_opts.erl
+++ b/test/enm_opts.erl
@@ -195,6 +195,8 @@ mode() ->
 misc() ->
     {ok,Req} = enm:req([{resend_ivl,5000}]),
     ?assertMatch({ok,[{resend_ivl,5000}]}, enm:getopts(Req, [resend_ivl])),
+    ok = enm:setopts(Req, [{ipv4only,false}]),
+    ?assertMatch({ok,[{ipv4only,false}]}, enm:getopts(Req, [ipv4only])),
     ok = enm:setopts(Req, [{sndbuf,345678}]),
     ?assertMatch({ok,[{sndbuf,345678}]}, enm:getopts(Req, [sndbuf])),
     ok = enm:setopts(Req, [{rcvbuf,456789}]),


### PR DESCRIPTION
In order to use IPv6 interfaces you must be able to set the
`NN_IPV4ONLY` option.