### PR TITLE
Use rlimit.rlim_cur for socket tracking table size

### DIFF
--- a/c_src/enm_drv.c
+++ b/c_src/enm_drv.c
@@ -170,7 +170,7 @@ enm_init()
 
     if (getrlimit(RLIMIT_NOFILE, &rl) < 0)
         return -1;
-    enm_sockets = (EnmData**)driver_alloc(rl.rlim_max * sizeof(EnmData*));
+    enm_sockets = (EnmData**)driver_alloc(rl.rlim_cur * sizeof(EnmData*));
     if (enm_sockets == 0)
         return -1;
     return 0;


### PR DESCRIPTION
On OS X Yosemite, getrlimit can return a large bogus value for the
rlimit.rlim_max field. This field was used during enm driver
initialization as part of allocating a file descriptor table, and the
bogus value was causing a memory allocation failure with driver_alloc
because the size being requested was much too high. Use the
rlimit.rlim_cur field instead to calculate the amount of memory needed
for the table.