### PR TITLE
Fix #15: return after driver_failure calls

### DIFF
--- a/c_src/enm.h
+++ b/c_src/enm.h
@@ -120,13 +120,19 @@ typedef struct {
     } b;
 }  EnmArgs;
 
+typedef enum {
+    ENM_NANOMSG_ERROR,
+    ENM_POSIX_ERROR,
+    ENM_UNKNOWN_ERROR
+} EnmErrorType;
+
 extern int enm_write_select(EnmData* d, int start);
 extern int enm_read_select(EnmData* d, int start);
 extern ErlDrvSSizeT enm_getopts(EnmData* d, EnmArgs* args);
 extern ErlDrvSSizeT enm_setopts_priv(EnmData* d, int opt, EnmArgs* args);
 extern ErlDrvSSizeT enm_setopts(EnmData* d, EnmArgs* args);
 extern ErlDrvSSizeT enm_ok(char* buf);
-extern void enm_errno_str(int err, char* errstr);
+extern EnmErrorType enm_errno_str(int err, char* errstr);
 extern ErlDrvSSizeT enm_errno_tuple(char* buf, int err);
 extern ErlDrvTermData enm_errno_atom(int err);
 extern const char* enm_protocol_name(int protocol);

--- a/c_src/enm_utils.c
+++ b/c_src/enm_utils.c
@@ -33,25 +33,31 @@ enm_ok(char* buf)
     return index;
 }
 
-void
+EnmErrorType
 enm_errno_str(int err, char* errstr)
 {
+    EnmErrorType errtype = ENM_UNKNOWN_ERROR;
+    errstr[0] = '\0';
     strcpy(errstr, erl_errno_id(err));
-    if (strcmp(errstr, "unknown") == 0) {
+    if (strcmp(errstr, "unknown") != 0)
+        return ENM_POSIX_ERROR;
+    else {
         switch (err) {
         case EFSM:
             strcpy(errstr, "efsm");
+            errtype = ENM_NANOMSG_ERROR;
             break;
         case ETERM:
             strcpy(errstr, "eterm");
+            errtype = ENM_NANOMSG_ERROR;
             break;
         default:
             /* default in case nanomsg adds new errno values
              * not accounted for here */
-            strcpy(errstr, "enanomsg");
             break;
         }
     }
+    return errtype;
 }
 
 ErlDrvSSizeT


### PR DESCRIPTION
In the driver, functions calling driver_failure were not returning
immediately afterward, and so any code in the remainder of such a
function that tried to access driver state could cause access
violations due to that state already having been destroyed. Fix these
calls, and also modify which driver_failure functions are called so as
to make errors as descriptive as possible.