### PR TITLE
Add support for socket reconnect interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ can also be read from `enm` sockets. `enm` supports the following options:
   specifically a `push` or `pub` socket, results in a `badarg` exception.
 * `nodelay`: if true, set the `TCP_NODELAY` option on TCP sockets, or if
   false, clear it.
+* `reconnect_ivl`: set the reconnect interval to specify how long, in
+  milliseconds, to wait before attempting to reconnect a broken socket
+  connection. The supplied value must be greater than 0, otherwise a
+  `badarg` exception results. The default is 100.
+* `reconnect_ivl_max`: set the maximum reconnect interval in
+  milliseconds. If this value is greater than the default of 0, socket
+  reconnection attempts will use exponential backoff starting with the
+  socket's `reconnect_ivl` value and doubling it on each reconnection
+  attempt, but will ensure the backoff value never exceeds the specified
+  `reconnect_ivl_max` value. With the default value of 0, no exponential
+  backoff is used, and only the `reconnect_ivl` setting controls
+  reconnection wait time.
 
 Currently, most but not all nanomsg socket options are implemented. Please
 file an issue or submit a pull request if an option you need is missing.

--- a/c_src/enm.h
+++ b/c_src/enm.h
@@ -5,7 +5,7 @@
 //
 // enm.h: common definitions for nanomsg Erlang language binding
 //
-// Copyright (c) 2014 Basho Technologies, Inc. All Rights Reserved.
+// Copyright (c) 2014-2016 Basho Technologies, Inc. All Rights Reserved.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file
@@ -69,6 +69,8 @@
 #define ENM_RCVBUF      19
 #define ENM_NODELAY     20
 #define ENM_IPV4ONLY    21
+#define ENM_RECONNECT_IVL 22
+#define ENM_RECONNECT_IVL_MAX 23
 
 #define IDXSHFT(P,I,SH) ((int)(((unsigned char)((P)[I]))<<(SH)))
 #define GETINT16(P) (IDXSHFT(P,0,8) | IDXSHFT(P,1,0))
@@ -115,6 +117,8 @@ typedef struct {
     int resend_ivl;
     int sndbuf;
     int rcvbuf;
+    int reconnect_ivl;
+    int reconnect_ivl_max;
     struct {
         unsigned topic_seen: 1;
     } b;

--- a/test/enm_opts.erl
+++ b/test/enm_opts.erl
@@ -2,7 +2,7 @@
 %%
 %% enm_opts: option tests for enm
 %%
-%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2014-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -201,6 +201,12 @@ misc() ->
     ?assertMatch({ok,[{sndbuf,345678}]}, enm:getopts(Req, [sndbuf])),
     ok = enm:setopts(Req, [{rcvbuf,456789}]),
     ?assertMatch({ok,[{rcvbuf,456789}]}, enm:getopts(Req, [rcvbuf])),
+    ok = enm:setopts(Req, [{reconnect_ivl,2000}]),
+    ?assertMatch({ok,[{reconnect_ivl,2000}]},
+                 enm:getopts(Req, [reconnect_ivl])),
+    ok = enm:setopts(Req, [{reconnect_ivl_max,5000}]),
+    ?assertMatch({ok,[{reconnect_ivl_max,5000}]},
+                 enm:getopts(Req, [reconnect_ivl_max])),
     ?assertMatch({error,einval}, enm:pull([{sndbuf,12345678}])),
     ?assertMatch({error,einval}, enm:sub([{sndbuf,12345678}])),
     ?assertMatch({error,einval}, enm:push([{rcvbuf,12345678}])),


### PR DESCRIPTION
Add the `reconnect_ivl` and `reconnect_ivl_max` socket options. The
`reconnect_ivl` option corresponds to the underlying nanomsg
`NN_RECONNECT_IVL` socket option used to control how long a disconnected
socket will wait before attempting to reconnect. The `reconnect_ivl_max`
option corresponds to the nanomsg `NN_RECONNECT_IVL_MAX` option used to
set the maximum exponential backoff duration for socket reconnect.
Also add tests and documentation for these two options.